### PR TITLE
診断結果を返却するAPIを実装

### DIFF
--- a/app/handler/diagnosis.go
+++ b/app/handler/diagnosis.go
@@ -1,0 +1,1 @@
+package handler

--- a/app/handler/diagnosis.go
+++ b/app/handler/diagnosis.go
@@ -1,6 +1,13 @@
 package handler
 
-import "net/http"
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+type RequestBodyDiagnosis struct {
+}
 
 type DiagnosisHandler struct {
 	// dbやconfigを入れて拡張できるようにして多く
@@ -12,5 +19,11 @@ func NewDiagnosisHandler() *DiagnosisHandler {
 }
 
 func (h *DiagnosisHandler) Handle(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
+	var req RequestBodyDiagnosis
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		log.Printf("failed to decode request: %v", err)
+		http.Error(w, "DiagnosisHandler: Invalid input", http.StatusBadRequest)
+		return
+	}
+
 }

--- a/app/handler/diagnosis.go
+++ b/app/handler/diagnosis.go
@@ -6,7 +6,12 @@ import (
 	"net/http"
 )
 
+type Answers struct {
+	Answer string
+}
+
 type RequestBodyDiagnosis struct {
+	Answers []string
 }
 
 type DiagnosisHandler struct {

--- a/app/handler/diagnosis.go
+++ b/app/handler/diagnosis.go
@@ -1,1 +1,16 @@
 package handler
+
+import "net/http"
+
+type DiagnosisHandler struct {
+	// dbやconfigを入れて拡張できるようにして多く
+	// db *sql.DB
+}
+
+func NewDiagnosisHandler() *DiagnosisHandler {
+	return &DiagnosisHandler{}
+}
+
+func (h *DiagnosisHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/app/handler/diagnosis.go
+++ b/app/handler/diagnosis.go
@@ -11,7 +11,12 @@ type Answers struct {
 }
 
 type RequestBodyDiagnosis struct {
-	Answers []string
+	Answers []string `json:"answers"`
+}
+
+type ResponseDiagnosis struct {
+	Type           string   `json:"type"`
+	Recomendations []string `json:"recommendations"`
 }
 
 type DiagnosisHandler struct {
@@ -31,4 +36,36 @@ func (h *DiagnosisHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	counts := map[string]int{}
+	for _, answer := range req.Answers {
+		counts[answer]++
+	}
+
+	// 最も多いタイプ
+	var maxType string
+	maxCount := -1
+	for typ, cnt := range counts {
+		if cnt > maxCount {
+			maxType = typ
+			maxCount = cnt
+		}
+	}
+
+	// タイプごとのメニューを定義（将来的にはDBや設定ファイルでもOK）
+	recommendationMap := map[string][]string{
+		"A": {"ピラミッド法", "アセンディング法", "ディセンディング法"},
+		"B": {"5x5法", "3x3法"},
+		"C": {"有酸素運動"},
+	}
+
+	resp := ResponseDiagnosis{
+		Type:           maxType,
+		Recomendations: recommendationMap[maxType],
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Printf("DiagnoseHandler: failed to encode response: %v", err)
+	}
 }

--- a/app/handler/diagnosis_test.go
+++ b/app/handler/diagnosis_test.go
@@ -1,0 +1,1 @@
+package handler_test

--- a/app/handler/diagnosis_test.go
+++ b/app/handler/diagnosis_test.go
@@ -1,1 +1,83 @@
 package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/y-soliloquy/kintore-pocket-backend/app/handler"
+)
+
+func TestDiagnosisHandler_Handle(t *testing.T) {
+	tests := []struct {
+		name          string
+		request       handler.RequestBodyDiagnosis
+		expectedType  string
+		expectedMenus []string
+	}{
+		{
+			name: "type A wins",
+			request: handler.RequestBodyDiagnosis{
+				Answers: []string{"A", "A", "B", "C"},
+			},
+			expectedType:  "A",
+			expectedMenus: []string{"ピラミッド法", "アセンディング法", "ディセンディング法"},
+		},
+		{
+			name: "type C wins",
+			request: handler.RequestBodyDiagnosis{
+				Answers: []string{"C", "C", "A", "B"},
+			},
+			expectedType:  "C",
+			expectedMenus: []string{"有酸素運動"},
+		},
+		{
+			name: "type B wins",
+			request: handler.RequestBodyDiagnosis{
+				Answers: []string{"B", "B", "B", "C"},
+			},
+			expectedType:  "B",
+			expectedMenus: []string{"5x5法", "3x3法"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := json.Marshal(tt.request)
+			if err != nil {
+				t.Fatalf("failed to marshal request: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/diagnosis", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+
+			h := handler.NewDiagnosisHandler()
+			h.Handle(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("unexpected status code: got %d, want %d", rr.Code, http.StatusOK)
+			}
+
+			var got handler.ResponseDiagnosis
+			if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+
+			if got.Type != tt.expectedType {
+				t.Errorf("unexpected type: got %s, want %s", got.Type, tt.expectedType)
+			}
+
+			if len(got.Recomendations) != len(tt.expectedMenus) {
+				t.Fatalf("unexpected recommendations length: got %d, want %d", len(got.Recomendations), len(tt.expectedMenus))
+			}
+			for i := range got.Recomendations {
+				if got.Recomendations[i] != tt.expectedMenus[i] {
+					t.Errorf("recommendation[%d]: got %s, want %s", i, got.Recomendations[i], tt.expectedMenus[i])
+				}
+			}
+		})
+	}
+}

--- a/app/handler/training_menu.go
+++ b/app/handler/training_menu.go
@@ -27,7 +27,7 @@ type TrainingMenu struct {
 	Reps   int     `json:"reps"`
 }
 
-type RequestBody struct {
+type RequestBodyTrainingMenu struct {
 	Weight int `json:"weight"`
 }
 
@@ -44,7 +44,7 @@ func NewTrainingMenuHandler(path string) *TrainingMenuHandler {
 // ゆくゆくは、メニュータイプも受け取って、このAPIだけで複数のメニューを返すようにしたい。
 // その際は名前を汎用的なものに変更する
 func (h *TrainingMenuHandler) Handle(w http.ResponseWriter, r *http.Request) {
-	var req RequestBody
+	var req RequestBodyTrainingMenu
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		log.Printf("failed to decode request: %v", err)
 		http.Error(w, "TrainingMenuHandler: Invalid input", http.StatusBadRequest)

--- a/app/router/router.go
+++ b/app/router/router.go
@@ -30,6 +30,7 @@ func NewRouter() http.Handler {
 		{Method: http.MethodGet, Path: "/goodbye", Handler: handler.NewGoodbyeHandler().Handle},
 		{Method: http.MethodPost, Path: "/training_menu", Handler: handler.NewTrainingMenuHandler("data").Handle},
 		{Method: http.MethodGet, Path: "/questions", Handler: handler.NewQuestionsHandler("data").Handle},
+		{Method: http.MethodPost, Path: "/diagnosis", Handler: handler.NewDiagnosisHandler().Handle},
 	}
 
 	for _, route := range routes {


### PR DESCRIPTION
## 関連資料のURL
<!-- なければ貼る必要はなし -->

- https://github.com/y-soliloquy/kintore-pocket-backend/issues/18#issue-3249212581

## 詳細

- 診断結果を返却する`/diagnosis`を実装
- テスト

## 挙動確認

```shell
$ curl -v -X POST "http://localhost:8080/diagnosis" -d '{"answers":["A","B","C","C"]}' -H "Content-Type: application/json"
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> POST /diagnosis HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 29
> 
< HTTP/1.1 200 OK
< Content-Type: application/json
< Vary: Origin
< Date: Sat, 26 Jul 2025 09:48:25 GMT
< Content-Length: 51
< 
{"type":"C","recommendations":["有酸素運動"]}
* Connection #0 to host localhost left intact
```

## 質問リスト

- [ ] メンテナンスですか？
- [x] 機能追加ですか？
- [ ] バグフィックスですか？
- [x] テストは書きましたか？
  - 必要ない場合はその旨を記載

## 共有・注意点など
